### PR TITLE
Revise .png file referenced for initial histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ We are only interested in the heigt column, so we'll save this now as a list.
 
 
 ```python
-v
+height = df.height
 print (len(height))
 print (height)
 ```
@@ -154,7 +154,7 @@ In the cell below, Import matplotlib as we saw earlier and plot a histogram of t
 # Expected output below
 ```
 
-![](index_files/index_22_0.png)
+![](index_files/index_9_1.png)
 
 Do you spot anything unsual above , some outliers maybe ?
 

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ Follow the boxplot method shown earier and build a boxplot for height data. See 
 ### Findings
 So there we have it. We have done an indepth analysis of individuals' heights using measure of central tendency of the data (67 - 68) inches, and the standard spread of the data to be around 9 inches around the mean. So we can expect half of the individuals to lie between 64 to 71 inches, as the IQR range covers 50% of the samples. These figures have been confirmed by our calculations as well as visual analysis of the data with histograms and boxplots. 
 
-We shall learn how o further this analysis using more sophisticated statistical methods as models as we progress through the course. We shall also learn how these basic techniques provide you with a strong foundation to develop your intuitions for machine learning and predictive analysis. 
+We shall learn how to further this analysis using more sophisticated statistical methods as models as we progress through the course. We shall also learn how these basic techniques provide you with a strong foundation to develop your intuitions for machine learning and predictive analysis. 
 
 ## Summary 
 

--- a/index.ipynb
+++ b/index.ipynb
@@ -180,7 +180,7 @@
     }
    ],
    "source": [
-    "v\n",
+    "height = df.height\n",
     "print (len(height))\n",
     "print (height)"
    ]
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](index_files/index_22_0.png)"
+    "![](index_files/index_9_1.png)"
    ]
   },
   {
@@ -874,7 +874,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Overview
Initial histogram was incorrectly showing the `height_filtered` distribution and not the original `height` distribution. Additionally, there a variable `v` that was mentioned but never initialized so I replaced it with `height = df.height`.

## Note
This appears in both the `master` and `solution` branch.

#staff